### PR TITLE
Use assertEquals with object fields instead of instances.

### DIFF
--- a/src/picklefield/tests.py
+++ b/src/picklefield/tests.py
@@ -146,5 +146,7 @@ class PickledObjectFieldTests(TestCase):
                           ' "model": "picklefield.minimaltestingmodel",'
                           ' "fields": {"pickle_field": "gAJ9cQFVA2Zvb3ECVQNiYXJxA3Mu"}}]')
         for deserialized_test in serializers.deserialize('json', json_test):
-            self.assertEquals(deserialized_test.object,
-                              model_test)
+            self.assertEquals(deserialized_test.object.pk,
+                              model_test.pk)
+            self.assertEquals(deserialized_test.object.pickle_field,
+                              model_test.pickle_field)


### PR DESCRIPTION
Directly comparing objects with assertEquals requires them to either be the same
object instance or to provide the `__eq__` operator.
